### PR TITLE
Add support for Linux-based builds

### DIFF
--- a/Sources/BinaryReader.swift
+++ b/Sources/BinaryReader.swift
@@ -126,9 +126,9 @@ internal class BinaryReader {
         return try UnsafePointer(buffer).withMemoryRebound(to: UInt16.self, capacity: 1) {
             switch endian {
             case .big:
-                return CFSwapInt16BigToHost($0[0])
+                return UInt16(bigEndian: $0[0])
             case .little:
-                return CFSwapInt16LittleToHost($0[0])
+                return UInt16(littleEndian: $0[0])
             default:
                 throw CSVError.stringEndianMismatch
             }
@@ -147,9 +147,9 @@ internal class BinaryReader {
         return try UnsafePointer(buffer).withMemoryRebound(to: UInt32.self, capacity: 1) {
             switch endian {
             case .big:
-                return CFSwapInt32BigToHost($0[0])
+                return UInt32(bigEndian: $0[0])
             case .little:
-                return CFSwapInt32LittleToHost($0[0])
+                return UInt32(littleEndian: $0[0])
             default:
                 throw CSVError.stringEndianMismatch
             }

--- a/Tests/CSVTests/CSVTests.swift
+++ b/Tests/CSVTests/CSVTests.swift
@@ -11,6 +11,21 @@ import XCTest
 
 class CSVTests: XCTestCase {
     
+    static let allTests = [
+        ("testOneLine", testOneLine),
+        ("testTwoLines", testTwoLines),
+        ("testLastLineIsEmpty", testLastLineIsEmpty),
+        ("testLastLineIsWhiteSpace", testLastLineIsWhiteSpace),
+        ("testMiddleLineIsEmpty", testMiddleLineIsEmpty),
+        ("testCommaInQuotationMarks", testCommaInQuotationMarks),
+        ("testEscapedQuotationMark1", testEscapedQuotationMark1),
+        ("testEscapedQuotationMark2", testEscapedQuotationMark2),
+        ("testEmptyField", testEmptyField),
+        ("testDoubleQuoteBeforeLineBreak", testDoubleQuoteBeforeLineBreak),
+        ("testSubscript", testSubscript),
+        ("testCSVState1", testCSVState1)
+    ]
+    
     func testOneLine() {
         let csv = "\"abc\",1,2"
         var i = 0

--- a/Tests/CSVTests/LineBreakTests.swift
+++ b/Tests/CSVTests/LineBreakTests.swift
@@ -10,6 +10,21 @@ import XCTest
 @testable import CSV
 
 class LineBreakTests: XCTestCase {
+    
+    static let allTests = [
+        ("testLF", testLF),
+        ("testCRLF", testCRLF),
+        ("testLastCR", testLastCR),
+        ("testLastCRLF", testLastCRLF),
+        ("testLastLF", testLastLF),
+        ("testLFInQuotationMarks", testLFInQuotationMarks),
+        ("testLineBreakLF", testLineBreakLF),
+        ("testLineBreakCR", testLineBreakCR),
+        ("testLineBreakCRLF", testLineBreakCRLF),
+        ("testLineBreakLFLF", testLineBreakLFLF),
+        ("testLineBreakCRCR", testLineBreakCRCR),
+        ("testLineBreakCRLFCRLF", testLineBreakCRLFCRLF)
+    ]
 
     func testLF() {
         let csv = "abab,cdcd,efef\nzxcv,asdf,qwer"

--- a/Tests/CSVTests/ReadmeTests.swift
+++ b/Tests/CSVTests/ReadmeTests.swift
@@ -11,6 +11,14 @@ import XCTest
 
 class ReadmeTests: XCTestCase {
     
+    static let allTests = [
+        ("testFromCSVString", testFromCSVString),
+        ("testFromFilePath", testFromFilePath),
+        ("testGettingTheHeaderRow", testGettingTheHeaderRow),
+        ("testGetTheFieldValueUsingSubscript", testGetTheFieldValueUsingSubscript),
+        ("testProvideTheCharacterEncoding", testProvideTheCharacterEncoding)
+    ]
+    
     func testFromCSVString() {
         for row in try! CSV(string: "1,foo\n2,bar") {
             print("\(row)")

--- a/Tests/CSVTests/TrimFieldsTests.swift
+++ b/Tests/CSVTests/TrimFieldsTests.swift
@@ -10,6 +10,22 @@ import XCTest
 @testable import CSV
 
 class TrimFieldsTests: XCTestCase {
+    
+    static let allTests = [
+        ("testTrimFields1", testTrimFields1),
+        ("testTrimFields2", testTrimFields2),
+        ("testTrimFields3", testTrimFields3),
+        ("testTrimFields4", testTrimFields4),
+        ("testTrimFields5", testTrimFields5),
+        ("testTrimFields6", testTrimFields6),
+        ("testTrimFields7", testTrimFields7),
+        ("testTrimFields8", testTrimFields8),
+        ("testTrimFields9", testTrimFields9),
+        ("testTrimFields10", testTrimFields10),
+        ("testTrimFields11", testTrimFields11),
+        ("testTrimFields12", testTrimFields12),
+        ("testTrimFields13", testTrimFields13),
+    ]
 
     func testTrimFields1() {
         let csvString = "abc,def,ghi"

--- a/Tests/CSVTests/UnicodeTests.swift
+++ b/Tests/CSVTests/UnicodeTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 yaslab. All rights reserved.
 //
 
+import Foundation
 import XCTest
 @testable import CSV
 

--- a/Tests/CSVTests/UnicodeTests.swift
+++ b/Tests/CSVTests/UnicodeTests.swift
@@ -11,6 +11,16 @@ import XCTest
 @testable import CSV
 
 class UnicodeTests: XCTestCase {
+    
+    static let allTests = [
+        ("testUTF8WithBOM", testUTF8WithBOM),
+        ("testUTF16WithNativeEndianBOM", testUTF16WithNativeEndianBOM),
+        ("testUTF16WithBigEndianBOM", testUTF16WithBigEndianBOM),
+        ("testUTF16WithLittleEndianBOM", testUTF16WithLittleEndianBOM),
+        ("testUTF32WithNativeEndianBOM", testUTF32WithNativeEndianBOM),
+        ("testUTF32WithBigEndianBOM", testUTF32WithBigEndianBOM),
+        ("testUTF32WithLittleEndianBOM", testUTF32WithLittleEndianBOM)
+    ]
 
     func testUTF8WithBOM() {
         let csvString = "abab,,cdcd,efef\r\nzxcv,asdf,\"qw\"\"er\","

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,8 +7,12 @@
 //
 
 import XCTest
-@testable import CSVTestSuite
+@testable import CSVTests
 
 XCTMain([
-     testCase(CSVReaderTests.allTests),
+     testCase(CSVTests.allTests),
+     testCase(LineBreakTests.allTests),
+     testCase(ReadmeTests.allTests),
+     testCase(TrimFieldsTests.allTests),
+     testCase(UnicodeTests.allTests)
 ])


### PR DESCRIPTION
Thanks for this library. I fixed a few issues that prevented CSV to run on Linux.

You can use the following command to build and run the unit tests on Ubuntu (requires [Docker](https://docs.docker.com/docker-for-mac/)):
```
docker run \
    --rm \
    --volume "$(pwd):/app" \
    --workdir /app \
    smithmicro/swift:3.0.1 \
    swift test --build-path .build/native
```

Would be great to have these fixes merged.
-Claus