### PR TITLE
[CSVWriter] csv.write not following RFC4180

### DIFF
--- a/Sources/CSV/CSVWriter.swift
+++ b/Sources/CSV/CSVWriter.swift
@@ -182,6 +182,11 @@ extension CSVWriter {
 
         var value = value
 
+        var quoted = quoted
+        if value.contains("\"") {
+            quoted = true
+        }
+
         if quoted {
             value = value.replacingOccurrences(of: DQUOTE_STR, with: DQUOTE2_STR)
             try writeScalar(DQUOTE)

--- a/Tests/CSVTests/CSVWriterTests.swift
+++ b/Tests/CSVTests/CSVWriterTests.swift
@@ -166,6 +166,22 @@ class CSVWriterTests: XCTestCase {
         XCTAssertEqual(csvStr, "\(str)-1,\"\(str)-\"\"-2\"")
     }
 
+    /// csv.write(row: ["xxxx", "xx,\"xx"])
+    /// -> xxxx,"xx,""xx"
+    func testEscapeQuoteAutomatically() {
+        let stream = OutputStream(toMemory: ())
+        stream.open()
+        
+        let csv = try! CSVWriter(stream: stream)
+        try! csv.write(row: ["id", "testing,\"comma"]) // quoted: false
+        
+        stream.close()
+        let data = stream.data!
+        let csvStr = String(data: data, encoding: .utf8)!
+        
+        XCTAssertEqual(csvStr, "id,\"testing,\"\"comma\"")
+    }
+    
     /// Test delimiter: "\t"
     func testDelimiter() {
         let stream = OutputStream(toMemory: ())


### PR DESCRIPTION
This pull request resolves #52.