### PR TITLE
Added support for decoding with  Int-based CodingKey

### DIFF
--- a/Sources/CSV/CSVReader+Decodable.swift
+++ b/Sources/CSV/CSVReader+Decodable.swift
@@ -21,12 +21,14 @@ extension CSVReader {
         init() {}
 
         func decode<T: Decodable>(_ type: T.Type, from reader: CSVReader) throws -> T {
-            guard reader.headerRow != nil else {
-                throw DecodingError.typeMismatch(T.self,
-                                                       DecodingError.Context(codingPath: [],
-                                                                             debugDescription: "readRow(): Header row required to map to Decodable")
-                )
-            }
+            
+            
+//            guard reader.headerRow != nil else {
+//                throw DecodingError.typeMismatch(T.self,
+//                                                       DecodingError.Context(codingPath: [],
+//                                                                             debugDescription: "readRow(): Header row required to map to Decodable")
+//                )
+//            }
             let decoder = _CSVRowDecoder(referencing: reader, at: [], userInfo: [:])
             return try T(from: decoder)
         }
@@ -91,11 +93,14 @@ extension CSVReader {
         }
 
         func contains(_ key: K) -> Bool {
+            guard let index = key.intValue else {
             return decoder.reader[key.stringValue] != nil
+            }
+            return index < decoder.reader.currentRow!.count
         }
 
         func decodeNil(forKey key: K) throws -> Bool {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -103,7 +108,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Bool.Type, forKey key: K) throws -> Bool {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -117,7 +122,7 @@ extension CSVReader {
         }
 
         func decode(_ type: String.Type, forKey key: K) throws -> String {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -131,7 +136,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Double.Type, forKey key: K) throws -> Double {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -145,7 +150,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Float.Type, forKey key: K) throws -> Float {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -159,7 +164,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Int.Type, forKey key: K) throws -> Int {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -173,7 +178,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Int8.Type, forKey key: K) throws -> Int8 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -187,7 +192,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Int16.Type, forKey key: K) throws -> Int16 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -201,7 +206,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Int32.Type, forKey key: K) throws -> Int32 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -215,7 +220,7 @@ extension CSVReader {
         }
 
         func decode(_ type: Int64.Type, forKey key: K) throws -> Int64 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -229,7 +234,7 @@ extension CSVReader {
         }
 
         func decode(_ type: UInt.Type, forKey key: K) throws -> UInt {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -243,7 +248,7 @@ extension CSVReader {
         }
 
         func decode(_ type: UInt8.Type, forKey key: K) throws -> UInt8 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -257,7 +262,7 @@ extension CSVReader {
         }
 
         func decode(_ type: UInt16.Type, forKey key: K) throws -> UInt16 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -271,7 +276,7 @@ extension CSVReader {
         }
 
         func decode(_ type: UInt32.Type, forKey key: K) throws -> UInt32 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -285,7 +290,7 @@ extension CSVReader {
         }
 
         func decode(_ type: UInt64.Type, forKey key: K) throws -> UInt64 {
-            guard let field = decoder.reader[key.stringValue] else {
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -299,7 +304,8 @@ extension CSVReader {
         }
 
         func decode<T>(_ type: T.Type, forKey key: K) throws -> T where T: Decodable {
-            guard let field = decoder.reader[key.stringValue] else {
+
+            guard let field = self.value(for: key) else {
                 throw DecodingError.keyNotFound(key, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "No value associated with key \(_errorDescription(of: key))."))
             }
 
@@ -310,6 +316,17 @@ extension CSVReader {
                 throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.decoder.codingPath, debugDescription: "Expected \(type) value but found null instead."))
             }
             return result
+        }
+        
+        func value(for codingKey: CodingKey) -> String? {
+            var value: String? = nil
+            
+            if let index = codingKey.intValue {
+                value = decoder.reader[index]
+            } else {
+                value = decoder.reader[codingKey.stringValue]
+            }
+            return value
         }
 
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: K) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
@@ -351,7 +368,10 @@ extension CSVReader._CSVRowDecoder: SingleValueDecodingContainer {
 
         private var value: String {
             let key = codingPath.last!
-            return reader[key.stringValue]!
+            guard let index = key.intValue else {
+                return reader[key.stringValue]!
+            }
+            return reader[index]!
         }
 
         private func expectNonNull<T>(_ type: T.Type) throws {

--- a/Sources/CSV/CSVReader.swift
+++ b/Sources/CSV/CSVReader.swift
@@ -394,5 +394,15 @@ extension CSVReader {
         }
         return row[index]
     }
+    
+    public subscript(key: Int) -> String? {
+        guard let row = currentRow else {
+            fatalError("CSVReader.currentRow must not be nil")
+        }
+        if key >= row.count {
+            return nil
+        }
+        return row[key]
+    }
 
 }

--- a/Tests/CSVTests/CSVReader+DecodableTests.swift
+++ b/Tests/CSVTests/CSVReader+DecodableTests.swift
@@ -12,7 +12,8 @@ import XCTest
 class CSVReader_DecodableTests: XCTestCase {
     static let allTests = [
         ("testNoHeader", testNoHeader),
-        ("testBasic", testBasic),
+        ("testStringCodingKey", testStringCodingKey),
+        ("testIntCodingKey", testIntCodingKey),
         ("testTypeMismatch", testTypeMismatch),
     ]
     
@@ -20,12 +21,17 @@ class CSVReader_DecodableTests: XCTestCase {
         case first
         case second
     }
+    
     struct SupportedDecodableExample: Decodable, Equatable {
         let intKey: Int
         let stringKey: String
         let optionalStringKey: String?
         let dateKey: Date
         let enumKey: Enum
+        
+        func toRow() -> String {
+            return "\(self.stringKey),\(self.optionalStringKey ?? ""),\(self.intKey),,\"\(CSVReader.dateFormatter.string(from: self.dateKey))\",\(self.enumKey)\n"
+        }
         
         static func ==(left: SupportedDecodableExample, right: SupportedDecodableExample) -> Bool {
             let formatter = CSVReader.dateFormatter
@@ -39,6 +45,41 @@ class CSVReader_DecodableTests: XCTestCase {
             return [
                 SupportedDecodableExample(intKey: 12345, stringKey: "stringValue", optionalStringKey: nil, dateKey: Date(), enumKey: .first),
                 SupportedDecodableExample(intKey: 54321, stringKey: "stringValue2", optionalStringKey: "withValue", dateKey: Date(timeInterval: 100, since: Date()), enumKey: .second)
+            ]
+        }
+    }
+    
+    struct IntKeyedDecodableExample: Decodable, Equatable {
+        private enum CodingKeys: Int, CodingKey {
+            case intKey = 2
+            case stringKey = 0
+            case optionalStringKey = 1
+            case dateKey = 4
+            case enumKey = 5
+        }
+        
+        let intKey: Int
+        let stringKey: String
+        let optionalStringKey: String?
+        let dateKey: Date
+        let enumKey: Enum
+        
+        func toRow() -> String {
+            return "\(self.stringKey),\(self.optionalStringKey ?? ""),\(self.intKey),,\"\(CSVReader.dateFormatter.string(from: self.dateKey))\",\(self.enumKey)\n"
+        }
+        
+        static func ==(left: IntKeyedDecodableExample, right: IntKeyedDecodableExample) -> Bool {
+            let formatter = CSVReader.dateFormatter
+            return left.intKey == right.intKey && left.stringKey == right.stringKey && left.optionalStringKey == right.optionalStringKey
+                //&& left.dateKey.compare(right.dateKey) == ComparisonResult.orderedSame // TODO: find more accurate conversion method, cannot compare directly likely because we are losing precision when in csv
+                && formatter.string(from: left.dateKey) == formatter.string(from: right.dateKey)
+                && left.enumKey == right.enumKey
+        }
+        
+        static var examples: [IntKeyedDecodableExample] {
+            return [
+                IntKeyedDecodableExample(intKey: 12345, stringKey: "stringValue", optionalStringKey: nil, dateKey: Date(), enumKey: .first),
+                IntKeyedDecodableExample(intKey: 54321, stringKey: "stringValue2", optionalStringKey: "withValue", dateKey: Date(timeInterval: 100, since: Date()), enumKey: .second)
             ]
         }
     }
@@ -58,24 +99,47 @@ class CSVReader_DecodableTests: XCTestCase {
         }
     }
     
-    func testBasic() {
+    func testStringCodingKey() {
         let headerConfig = CSVReader.Configuration(hasHeaderRow: true,
                                                    trimFields: false,
                                                    delimiter: ",",
                                                    whitespaces: .whitespaces)
         let exampleRecords = SupportedDecodableExample.examples
-        let dateFormatter = CSVReader.dateFormatter
         
-        let headerIt = """
-            stringKey,optionalStringKey,intKey,ignored,dateKey,enumKey
-            \(exampleRecords[0].stringKey),,\(exampleRecords[0].intKey),,\"\(dateFormatter.string(from: exampleRecords[0].dateKey))\",\(exampleRecords[0].enumKey)
-            \(exampleRecords[1].stringKey),\(exampleRecords[1].optionalStringKey!),\(exampleRecords[1].intKey),,\"\(dateFormatter.string(from: exampleRecords[1].dateKey))\",\(exampleRecords[1].enumKey)
-            """.unicodeScalars.makeIterator()
-        let headerCSV = try! CSVReader(iterator: headerIt, configuration: headerConfig)
+        let header = "stringKey,optionalStringKey,intKey,ignored,dateKey,enumKey\n"
+        let allRows = SupportedDecodableExample.examples.reduce(into: header) {  $0 += $1.toRow() }
+        let rowIterator = allRows.unicodeScalars.makeIterator()
+        
+        let headerCSV = try! CSVReader(iterator: rowIterator, configuration: headerConfig)
         
         var records = [SupportedDecodableExample]()
         do {
             while let record: SupportedDecodableExample = try headerCSV.readRow() {
+                records.append(record)
+            }
+        } catch {
+            XCTFail("readRow<T>() threw error: \(error)")
+        }
+        XCTAssertEqual(records.count, 2)
+        XCTAssertEqual(records[0], exampleRecords[0])
+        XCTAssertEqual(records[1], exampleRecords[1])
+    }
+    
+    func testIntCodingKey() {
+        let headerConfig = CSVReader.Configuration(hasHeaderRow: false,
+                                                   trimFields: false,
+                                                   delimiter: ",",
+                                                   whitespaces: .whitespaces)
+        let exampleRecords = IntKeyedDecodableExample.examples
+        
+        let allRows = IntKeyedDecodableExample.examples.reduce(into: "") {  $0 += $1.toRow() }
+        let rowIterator = allRows.unicodeScalars.makeIterator()
+        
+        let headerCSV = try! CSVReader(iterator: rowIterator, configuration: headerConfig)
+        
+        var records = [IntKeyedDecodableExample]()
+        do {
+            while let record: IntKeyedDecodableExample = try headerCSV.readRow() {
                 records.append(record)
             }
         } catch {


### PR DESCRIPTION
Developer may now opt to implement `Decodable` using `Int`-based `CodingKey`, instead of `String`.  This is particularly useful if the data does not have headers, or if the header strings are unwieldy.

Example `Decodable` implementation:

```swift
struct IntKeyedDecodableExample: Decodable, Equatable {
        private enum CodingKeys: Int, CodingKey {
            case intKey = 2
            case stringKey = 0
            case optionalStringKey = 1
            case dateKey = 4
            case enumKey = 5
        }
        
        let intKey: Int
        let stringKey: String
        let optionalStringKey: String?
        let dateKey: Date
        let enumKey: Enum
        
        func toRow() -> String {
            return "\(self.stringKey),\(self.optionalStringKey ?? ""),\(self.intKey),,\"\(CSVReader.dateFormatter.string(from: self.dateKey))\",\(self.enumKey)\n"
        }
        
        static func ==(left: IntKeyedDecodableExample, right: IntKeyedDecodableExample) -> Bool {
            let formatter = CSVReader.dateFormatter
            return left.intKey == right.intKey && left.stringKey == right.stringKey && left.optionalStringKey == right.optionalStringKey
                //&& left.dateKey.compare(right.dateKey) == ComparisonResult.orderedSame // TODO: find more accurate conversion method, cannot compare directly likely because we are losing precision when in csv
                && formatter.string(from: left.dateKey) == formatter.string(from: right.dateKey)
                && left.enumKey == right.enumKey
        }
        
        static var examples: [IntKeyedDecodableExample] {
            return [
                IntKeyedDecodableExample(intKey: 12345, stringKey: "stringValue", optionalStringKey: nil, dateKey: Date(), enumKey: .first),
                IntKeyedDecodableExample(intKey: 54321, stringKey: "stringValue2", optionalStringKey: "withValue", dateKey: Date(timeInterval: 100, since: Date()), enumKey: .second)
            ]
        }
    }
```