### PR TITLE
Make CSVWriter.write(row:_) generic to accept any Sequence

### DIFF
--- a/Sources/CSV/CSVWriter.swift
+++ b/Sources/CSV/CSVWriter.swift
@@ -201,7 +201,7 @@ extension CSVWriter {
         }
     }
 
-    public func write(row values: [String], quotedAtIndex: ((Int) -> Bool) = { _ in false }) throws {
+    public func write<S>(row values: S, quotedAtIndex: ((Int) -> Bool) = { _ in false }) throws where S: Sequence, S.Element == String {
         beginNewRow()
         for (i, value) in values.enumerated() {
             try write(field: value, quoted: quotedAtIndex(i))

--- a/Tests/CSVTests/CSVWriterTests.swift
+++ b/Tests/CSVTests/CSVWriterTests.swift
@@ -159,14 +159,14 @@ class CSVWriterTests: XCTestCase {
         XCTAssertEqual(csvStr, "id,\"testing,\"\"comma\"")
     }
 
-    /// csv.write(row: Set(["id", "cool"])
+    /// csv.write(row: NSArray(["id", "cool"])
     /// -> id,cool
-    func testSet() {
+    func testNSArray() {
         let stream = OutputStream.toMemory()
         stream.open()
 
         let csv = try! CSVWriter(stream: stream)
-        try! csv.write(row: Set(["id", "cool"])) // quoted: false
+        try! csv.write(row: NSArray(["id", "cool"])) // quoted: false
 
         stream.close()
         let data = stream.data!

--- a/Tests/CSVTests/CSVWriterTests.swift
+++ b/Tests/CSVTests/CSVWriterTests.swift
@@ -158,6 +158,22 @@ class CSVWriterTests: XCTestCase {
         
         XCTAssertEqual(csvStr, "id,\"testing,\"\"comma\"")
     }
+
+    /// csv.write(row: Set(["id", "cool"])
+    /// -> id,cool
+    func testSet() {
+        let stream = OutputStream.toMemory()
+        stream.open()
+
+        let csv = try! CSVWriter(stream: stream)
+        try! csv.write(row: Set(["id", "cool"])) // quoted: false
+
+        stream.close()
+        let data = stream.data!
+        let csvStr = String(data: data, encoding: .utf8)!
+
+        XCTAssertEqual(csvStr, "id,cool")
+    }
     
     /// csv.write(row: ["xxxx", "xx\rxx", "xx\nxx", "xx\r\nrxx"])
     /// -> xxxx,"xx\rxx","xx\nxx","xx\r\nxx"


### PR DESCRIPTION
This allows passing in other things besides Arrays